### PR TITLE
Logic added for add items block

### DIFF
--- a/src/Pages/OneOfMyCollectionsPage/OneOfMyCollectionsPage.jsx
+++ b/src/Pages/OneOfMyCollectionsPage/OneOfMyCollectionsPage.jsx
@@ -28,6 +28,8 @@ function OneOfMyCollectionsPage() {
         (c) => String(c.id) === String(id)
     )
 
+    console.log(items)
+
     useEffect(() => {
         if (status === 'idle') {
             dispatch(fetchCollections())
@@ -65,7 +67,7 @@ function OneOfMyCollectionsPage() {
             <ToggleButton />
             {itemsStatus === 'loading' && <Loading />}
             <section className={styles.itemContainer}>
-                {/* <AddItems /> */}
+                {items.length <= 0 && <AddItems />}
                 <div className={styles.grid}>
                     {items.map((item) => (
                         <ItemCard key={item.id} item={item} />


### PR DESCRIPTION
Quicker than I thought... added logic for the AddItems block to show when there's no items in a collection. Screenshot is from the Aquatic Pets collection that has no items(animals):  
<img width="1455" height="694" alt="Screenshot 2025-11-17 at 11 20 43" src="https://github.com/user-attachments/assets/0383bf54-bac1-4afa-907d-377853409216" />
